### PR TITLE
Run bundle install to be sure to use the updated version of capistrano

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -12,7 +12,7 @@ get '/deploy/:stage/:branch' do
   timestamp = Time.now.strftime('%Y%m%d%H%M')
   logfile = "log/deploy-"+timestamp+".log"
   loghtml = "log/deploy-"+timestamp+".html"
-  cmd = IO.popen("cd ~/apps/bridge ; git pull origin production ; ~/.rvm/bin/bridge_cap "+params[:stage]+" deploy tag="+params[:branch]+" ;")
+  cmd = IO.popen("cd ~/apps/bridge ; git pull origin production; ~/.rvm/bin/bundle install ; ~/.rvm/bin/bridge_cap "+params[:stage]+" deploy tag="+params[:branch]+" ;")
   log = cmd.readlines
   File.open(logfile, 'w') do |f|
       f.write log.join


### PR DESCRIPTION
After Leadformance/Bridge2#3768, Jarvis couldn't deploy anymore.

The `fog01` `thin.log` outputs the following stacktrace : 

``` ruby
127.0.0.1 - - [28/Apr/2014 11:03:20] "GET /deploy/prelive/5b95d9d HTTP/1.1" 200 79 5.8988
From github.com:Leadformance/Bridge2
 * branch            production -> FETCH_HEAD
cap aborted!
Capfile locked at 3.2.1, but 3.1.0 is loaded
/home/deployer/.rvm/gems/ruby-1.9.3-p327@bridge-dev/gems/capistrano-3.1.0/lib/capistrano/version_validator.rb:12:in `verify'
/home/deployer/.rvm/gems/ruby-1.9.3-p327@bridge-dev/gems/capistrano-3.1.0/lib/capistrano/dsl.rb:54:in `lock'
config/deploy.rb:1:in `<top (required)>'
/home/deployer/.rvm/gems/ruby-1.9.3-p327@bridge-dev/gems/capistrano-3.1.0/lib/capistrano/setup.rb:14:in `load'
/home/deployer/.rvm/gems/ruby-1.9.3-p327@bridge-dev/gems/capistrano-3.1.0/lib/capistrano/setup.rb:14:in `block (2 levels) in <top (required)>'
/home/deployer/.rvm/gems/ruby-1.9.3-p327@bridge-dev/gems/capistrano-3.1.0/lib/capistrano/application.rb:15:in `run'
/home/deployer/.rvm/gems/ruby-1.9.3-p327@bridge-dev/gems/capistrano-3.1.0/bin/cap:3:in `<top (required)>'
/home/deployer/.rvm/gems/ruby-1.9.3-p327@bridge-dev/bin/cap:23:in `load'
/home/deployer/.rvm/gems/ruby-1.9.3-p327@bridge-dev/bin/cap:23:in `<main>'
Tasks: TOP => prelive
(See full trace by running task with --trace)
```

So we need to run `bundle install` to get the latest gem on fog01.

WDYT @benflex ?
